### PR TITLE
Update README.md lab to ilab

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The full process is described graphically in the [workflow diagram](./docs/workf
    `taxonomy` seems to not exists or is empty. Should I clone https://github.com/instructlab/taxonomy.git for you? [y/N]: y
    Cloning https://github.com/instructlab/taxonomy.git...
    Generating `config.yaml` in the current directory...
-   Initialization completed successfully, you're ready to start using `lab`. Enjoy!
+   Initialization completed successfully, you're ready to start using `ilab`. Enjoy!
    ```
 
    `ilab` will use the default configuration file unless otherwise specified. You can override this behavior with the `--config` parameter for any `ilab` command.


### PR DESCRIPTION
# Changes
Minor update in the 'ilab init' output updating "you're ready to start using `lab`." to 'ilab'.

**Description of your changes:**
Minor update in the 'ilab init' output updating "you're ready to start using `lab`." to 'ilab'.